### PR TITLE
feat: /create-prカスタムコマンドを追加

### DIFF
--- a/.claude/commands/create-pr.md
+++ b/.claude/commands/create-pr.md
@@ -1,0 +1,89 @@
+---
+description: "包括的なPR作成ワークフロー - ブランチ作成、コミット、プッシュ、PR作成を自動化"
+allowed-tools: ["Bash", "Edit", "Read", "Glob", "Grep"]
+argument-hint: "[PR説明] - PR作成時の追加説明（オプション）"
+---
+
+# PR作成ワークフロー
+
+現在の変更から包括的なPR作成ワークフローを実行します：
+
+1. **ブランチ管理**: mainブランチにいる場合は適切なブランチを作成
+2. **コミット処理**: 変更内容を分析して意味のある単位でコミットを分割
+3. **品質チェック**: pnpm fix、pnpm check-types、pnpm checkを実行
+4. **プッシュ**: ブランチをリモートにプッシュ
+5. **PR作成**: プロジェクトのテンプレートに従ってPRを作成
+
+## 使用方法
+
+```bash
+# 基本使用
+/create-pr
+
+# 説明付き
+/create-pr "ユーザー認証機能の実装"
+
+# Issue参照付き
+/create-pr "ダークモード追加 (#123)"
+```
+
+## 実行される処理
+
+### 1. 現在の状態確認
+```bash
+git status
+git branch --show-current
+```
+
+### 2. ブランチ処理
+mainブランチにいる場合、変更内容を分析して適切なブランチを作成：
+- 新機能: `feat/description`
+- バグ修正: `fix/description` 
+- ドキュメント: `docs/description`
+- リファクタリング: `refactor/description`
+- テスト: `test/description`
+- その他: `chore/description`
+
+### 3. 変更の分析とコミット
+変更されたファイルを分析し、論理的な単位でコミットを分割：
+```bash
+git add <related-files>
+git commit -m "feat: 機能A実装"
+git add <other-files>
+git commit -m "style: コードフォーマット調整"
+```
+
+### 4. 品質チェック
+```bash
+pnpm fix           # コード自動修正
+pnpm check-types   # TypeScript型チェック
+pnpm check         # 包括的チェック
+```
+
+### 5. プッシュとPR作成
+```bash
+git push -u origin <branch-name>  # 新規ブランチの場合
+gh pr create --title "<title>" --body "<body>" --base main
+```
+
+## PRテンプレート連携
+
+`.github/pull_request_template.md`のテンプレートを使用し、以下を自動入力：
+
+- **概要**: コミットメッセージから生成
+- **変更内容**: 変更ファイルリストから生成
+- **影響範囲**: ファイルパスに基づいて自動チェック
+  - `apps/web` → Web アプリ
+  - `apps/native` → Native アプリ  
+  - `packages/ui` → 共有UIコンポーネント
+  - `packages/typescript-config` → TypeScript設定
+- **変更の種類**: ブランチ名から自動判定
+- **技術的チェックリスト**: 品質チェック実行後に自動チェック
+
+## 引数の使用
+
+`$ARGUMENTS`が提供された場合、PR説明に追加情報として含めます。
+
+---
+
+**注意**: このコマンドは変更をコミット・プッシュするため、実行前に変更内容を確認してください。


### PR DESCRIPTION
## 概要

Claude Codeの包括的なPR作成ワークフローを自動化するカスタムスラッシュコマンド `/create-pr` を追加しました。

## 変更内容

- `.claude/commands/create-pr.md` - 新しいカスタムコマンドファイル
- 包括的なPR作成ワークフローの自動化
  - ブランチ管理（mainから適切なブランチを作成）
  - インテリジェントコミット分割
  - 品質チェック（pnpm fix/check-types/check）
  - 自動プッシュ
  - PRテンプレート準拠のPR作成

### 影響範囲
- [x] その他のパッケージ: Claude Code設定

### 変更の種類
- [x] 新機能 (feat)

## 関連Issue

開発効率向上のためのツール追加

## テスト

### 技術的チェックリスト
- [x] `pnpm check-types` でエラーがない
- [x] TypeScriptエラーがない
- [x] 設定ファイルの構文が正しい

### 動作確認
- [x] ファイルが正しい場所に配置されている
- [x] YAMLフロントマターの構文が正しい
- [x] コマンドドキュメントが適切に記述されている

### テストケース
- [x] ファイル作成の確認
- [x] 構文チェック完了

## 依存関係の変更

### 依存関係の更新
- [x] package.jsonの変更なし

## セキュリティチェック

- [x] 機密情報（APIキー、トークン）がハードコードされていない
- [x] 設定ファイルに問題がない

## Turboリポ関連

- [x] ビルドキャッシュに影響なし
- [x] ワークスペース設定の変更が必要

## パフォーマンス

- [x] バンドルサイズに影響なし

## 使用方法

```bash
# 基本使用
/create-pr

# 説明付き
/create-pr "ユーザー認証機能の実装"

# Issue参照付き
/create-pr "ダークモード追加 (#123)"
```

## 注意事項・補足

- コマンドは次回のClaude Codeセッションから利用可能
- `/pr-comments`との名前衝突を避けるため`/create-pr`に命名
- プロジェクトのPRテンプレート（`.github/pull_request_template.md`）に完全準拠

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>