### PR TITLE
fix: Biome設定で.wranglerディレクトリを除外してpnpm fixエラーを解決

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -14,7 +14,8 @@
       "!**/build",
       "!**/.expo",
       "!**/.turbo",
-      "!**/.tamagui"
+      "!**/.tamagui",
+      "!**/.wrangler"
     ]
   },
   "formatter": {


### PR DESCRIPTION
## Summary
- Biome設定に`.wrangler`ディレクトリの除外を追加
- `pnpm fix`コマンドで発生していたエラーを解決
- Cloudflare Wranglerの一時ビルドファイルがlint対象から除外される

## Test plan
- [x] `pnpm fix`コマンドが正常に実行されることを確認
- [x] API開発時にWranglerの一時ファイルがlintされないことを確認
- [x] 他のアプリ（web, native, ui）のlintに影響がないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)