### PR TITLE
docs: CLAUDE.mdを整理し詳細情報を別ファイルに分割

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,172 +2,75 @@
 
 このファイルは、Claude Code (claude.ai/code)がこのリポジトリを効率的に扱うためのガイドです。
 
-## 目次
-
-- [プロジェクト概要](#プロジェクト概要)
-- [クイックスタート](#クイックスタート)
-- [コマンドリファレンス](#コマンドリファレンス)
-- [Claude Code設定](#claude-code設定)
-- [詳細ドキュメント](#詳細ドキュメント)
-
 ## プロジェクト概要
 
 **Next.js + Expo + Hono モノレポテンプレート**
 - Turborepo + pnpmによるモノレポ管理
-- TypeScript + Biome（コード品質）
+- TypeScript + Biome（コード品質）+ Tamagui（クロスプラットフォームUI）
 - Web（Next.js）、Native（Expo）、API（Hono）の同時開発
 
 ### 構成
 - `apps/web` - Next.js Webアプリ（ポート3000）
-- `apps/native` - Expo React Nativeアプリ
+- `apps/native` - Expo React Nativeアプリ  
 - `apps/api` - Hono APIアプリ（Cloudflare Workers、ポート8787）
-- `packages/ui` - 共有UIコンポーネント
+- `packages/ui` - Tamagui共有UIコンポーネント
 - `packages/typescript-config` - 共有TypeScript設定
 
-## クイックスタート
+## 基本コマンド
 
 ```bash
-# 依存関係のインストール
-pnpm install
-
 # 開発サーバー起動
 pnpm dev          # すべてのアプリ
 pnpm dev:web      # Webのみ
-pnpm dev:native   # Nativeのみ
+pnpm dev:native   # Nativeのみ  
 pnpm dev:api      # APIのみ
 
-# コード品質チェック
+# コード品質（コミット前必須）
 pnpm fix          # 自動修正
 pnpm check        # 包括的チェック
 ```
 
-## コマンドリファレンス
-
-| コマンド | 説明 | 使用場面 |
-|---------|------|---------|
-| `pnpm dev` | すべてのアプリを開発モードで起動 | 通常の開発時 |
-| `pnpm dev:web` | Webアプリのみ起動 | Web開発に集中したい時 |
-| `pnpm dev:native` | Nativeアプリのみ起動 | Native開発に集中したい時 |
-| `pnpm dev:api` | APIアプリのみ起動 | API開発に集中したい時 |
-| `pnpm build` | すべてのアプリをビルド | 本番デプロイ前 |
-| `pnpm fix` | コードの自動修正とフォーマット | コミット前（必須） |
-| `pnpm check` | lint + format + 型チェック | PR作成前（必須） |
-| `pnpm check-types` | TypeScript型チェックのみ | 型エラーの確認時 |
-
-### アプリ個別のコマンド
-
-```bash
-# Turboフィルターを使用
-turbo dev --filter=@repo/web
-turbo build --filter=@repo/native
-turbo dev --filter=@repo/api
-
-# Native特有のコマンド
-expo start --ios      # iOS開発
-expo start --android  # Android開発
-
-# API特有のコマンド
-cd apps/api && wrangler dev     # API開発サーバー起動
-cd apps/api && wrangler build   # APIビルド
-
-# API環境変数の設定
-cp apps/api/.dev.vars.example apps/api/.dev.vars  # 秘密情報設定
-```
 
 ## Claude Code設定
 
 ### 自動品質チェック（Hooks）
-
-コード変更時に自動実行される処理：
+コード変更時に自動実行：
 1. `pnpm fix` - コード自動修正
 2. `pnpm check-types` - 型チェック
 
-### MCP (Model Context Protocol)
-
-Playwright（ブラウザ自動化）とContext 7（最新ドキュメント参照）が利用可能です。
-
-詳細は [MCP設定ガイド](./docs/MCP.md) を参照してください。
-
 ### 権限設定
-
 - ✅ 許可: Git操作、pnpm/npmコマンド、ファイル読み書き
 - ❌ 禁止: sudo、rm -rf、機密ファイルへのアクセス
 
-## 開発のベストプラクティス
+### MCP (Model Context Protocol)
+Playwright（ブラウザ自動化）とContext 7（最新ドキュメント参照）が利用可能
 
-### 1. 新機能の追加
-- 共有コンポーネント → `packages/ui/src/`
-- アプリ固有コード → 各アプリの`src/`
+## 開発ルール
+
+### コード配置
+- 共有UI → `packages/ui/src/` (Tamaguiコンポーネント)
+- アプリ固有 → 各アプリの`src/`
 - 型定義 → 適切なパッケージの`types/`
 
-### 2. コミット前のチェックリスト
-- [ ] `pnpm fix`を実行
-- [ ] `pnpm check-types`でエラーがない
-- [ ] 不要なconsole.logを削除
-- [ ] コミットメッセージが規約に従っている
+### 依存関係管理
+- 最新バージョンを調べてからバージョン固定でインストール
+- エラー回避のためのバージョンダウンや削除は禁止
+- ファイル削除時はユーザーに確認必須
 
-### 3. 依存関係の追加
-```bash
-# ワークスペースのルート
-pnpm add -w <package>
+### コミット前チェックリスト
+- [ ] `pnpm fix` 実行
+- [ ] `pnpm check-types` でエラーなし
+- [ ] 不要なconsole.log削除
 
-# 特定のアプリ/パッケージ
-pnpm add <package> --filter=@repo/web
-```
-
-### 4. 依存関係管理とファイル操作のルール
-- ライブラリをインストールする際は、最新バージョンを調べてからバージョンを固定してインストールする
-- ファイルを削除する際は、必ずユーザーに確認を求める
-- エラー回避のために勝手にバージョンを下げたり、ライブラリを削除したりしない
-
-## トラブルシューティング
-
-### よくある問題と解決方法
-
-| 問題 | 解決方法 |
-|------|----------|
-| 型エラー | `pnpm check-types`で詳細確認 |
-| 依存関係の競合 | `pnpm install --force` |
-| キャッシュの問題 | `turbo daemon clean` |
-| Expoの問題 | `expo doctor`で環境チェック |
-| APIの問題 | `cd apps/api && wrangler dev`で詳細確認 |
-
-## API環境変数管理
-
-### 基本方針
-- **非秘密情報**: `wrangler.toml`に記載（Gitコミット対象）
-- **秘密情報**: `.dev.vars`で管理（Gitignore対象）
-
-### ローカル開発での設定
-```bash
-# 1. 設定ファイルをコピー
-cp apps/api/.dev.vars.example apps/api/.dev.vars
-
-# 2. 実際の値を設定
-# apps/api/.dev.vars を編集
-```
-
-### 環境変数の種類
-
-| 変数名 | 設定場所 | 用途 |
-|--------|----------|------|
-| `CORS_ORIGINS` | `wrangler.toml` | CORS許可オリジン |
-| `API_SECRET_KEY` | `.dev.vars` | API認証キー |
-| `DATABASE_URL` | `.dev.vars` | データベース接続文字列 |
-
-### 本番環境での設定
-```bash
-# Cloudflare Dashboard または wrangler secret コマンドを使用
-wrangler secret put API_SECRET_KEY
-wrangler secret put DATABASE_URL
-```
 
 ## 詳細ドキュメント
 
 - 📘 [開発ガイド](./docs/DEVELOPMENT.md) - アーキテクチャとパッケージの詳細
 - 📗 [Git/GitHubワークフロー](./docs/GIT_WORKFLOW.md) - ブランチルールとPR作成手順
-- 📙 [Claude設定詳細](./.claude/README.md) - Hooks設定とカスタマイズ
 - 🔧 [MCP設定ガイド](./docs/MCP.md) - MCPサーバーとContext 7の使用方法
+- 📙 [コマンドリファレンス](./docs/COMMANDS.md) - 詳細なコマンド一覧
+- 🔍 [トラブルシューティング](./docs/TROUBLESHOOTING.md) - よくある問題と解決方法
+- 🔑 [API設定ガイド](./docs/API.md) - 環境変数とAPI設定
 
 ---
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,60 @@
+# API設定ガイド
+
+このドキュメントでは、Hono APIアプリの環境変数管理とAPI設定について説明します。
+
+## 環境変数管理
+
+### 基本方針
+- **非秘密情報**: `wrangler.toml`に記載（Gitコミット対象）
+- **秘密情報**: `.dev.vars`で管理（Gitignore対象）
+
+### ローカル開発での設定
+
+```bash
+# 1. 設定ファイルをコピー
+cp apps/api/.dev.vars.example apps/api/.dev.vars
+
+# 2. 実際の値を設定
+# apps/api/.dev.vars を編集
+```
+
+### 環境変数の種類
+
+| 変数名 | 設定場所 | 用途 |
+|--------|----------|------|
+| `CORS_ORIGINS` | `wrangler.toml` | CORS許可オリジン |
+| `API_SECRET_KEY` | `.dev.vars` | API認証キー |
+| `DATABASE_URL` | `.dev.vars` | データベース接続文字列 |
+
+## 本番環境での設定
+
+```bash
+# Cloudflare Dashboard または wrangler secret コマンドを使用
+wrangler secret put API_SECRET_KEY
+wrangler secret put DATABASE_URL
+```
+
+## API開発コマンド
+
+```bash
+# API開発サーバー起動
+cd apps/api && wrangler dev
+
+# APIビルド
+cd apps/api && wrangler build
+
+# API環境変数の設定
+cp apps/api/.dev.vars.example apps/api/.dev.vars
+```
+
+## Cloudflare Workers 固有の設定
+
+### wrangler.toml
+- アプリケーション設定
+- 非秘密の環境変数
+- ルーティング設定
+
+### .dev.vars
+- 開発用の秘密情報
+- `.gitignore`で除外される
+- 本番では Cloudflare Dashboard で設定

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -1,0 +1,149 @@
+# コマンドリファレンス
+
+このドキュメントでは、プロジェクトで使用する全てのコマンドの詳細を説明します。
+
+## 基本コマンド
+
+| コマンド | 説明 | 使用場面 |
+|---------|------|---------|
+| `pnpm dev` | すべてのアプリを開発モードで起動 | 通常の開発時 |
+| `pnpm dev:web` | Webアプリのみ起動 | Web開発に集中したい時 |
+| `pnpm dev:native` | Nativeアプリのみ起動 | Native開発に集中したい時 |
+| `pnpm dev:api` | APIアプリのみ起動 | API開発に集中したい時 |
+| `pnpm build` | すべてのアプリをビルド | 本番デプロイ前 |
+| `pnpm fix` | コードの自動修正とフォーマット | コミット前（必須） |
+| `pnpm check` | lint + format + 型チェック | PR作成前（必須） |
+| `pnpm check-types` | TypeScript型チェックのみ | 型エラーの確認時 |
+
+## Turboフィルターコマンド
+
+```bash
+# 特定のアプリのみ実行
+turbo dev --filter=@repo/web
+turbo build --filter=@repo/native
+turbo dev --filter=@repo/api
+
+# 複数のアプリを指定
+turbo dev --filter=@repo/web --filter=@repo/api
+```
+
+## アプリ個別のコマンド
+
+### Native（Expo）
+
+```bash
+# 開発サーバー起動
+expo start
+
+# プラットフォーム別起動
+expo start --ios      # iOS開発
+expo start --android  # Android開発
+expo start --web      # Web開発
+
+# ビルド
+expo build:ios
+expo build:android
+
+# 環境確認
+expo doctor
+```
+
+### API（Hono + Cloudflare Workers）
+
+```bash
+# 開発サーバー起動
+cd apps/api && wrangler dev
+
+# ビルド
+cd apps/api && wrangler build
+
+# デプロイ
+cd apps/api && wrangler deploy
+
+# 環境変数設定
+cp apps/api/.dev.vars.example apps/api/.dev.vars
+```
+
+### Web（Next.js）
+
+```bash
+# 開発サーバー起動
+cd apps/web && pnpm dev
+
+# ビルド
+cd apps/web && pnpm build
+
+# 本番サーバー起動
+cd apps/web && pnpm start
+```
+
+## 依存関係管理
+
+```bash
+# ワークスペースのルートにパッケージ追加
+pnpm add -w <package>
+
+# 特定のアプリ/パッケージにパッケージ追加
+pnpm add <package> --filter=@repo/web
+pnpm add <package> --filter=@repo/native
+pnpm add <package> --filter=@repo/api
+pnpm add <package> --filter=@repo/ui
+
+# 開発依存関係として追加
+pnpm add -D <package> --filter=@repo/web
+
+# すべての依存関係をインストール
+pnpm install
+
+# 依存関係のクリーンインストール
+pnpm install --force
+```
+
+## キャッシュ管理
+
+```bash
+# Turboキャッシュをクリア
+turbo daemon clean
+
+# pnpmキャッシュをクリア
+pnpm store prune
+
+# node_modulesを削除して再インストール
+rm -rf node_modules apps/*/node_modules packages/*/node_modules
+pnpm install
+```
+
+## Git操作
+
+```bash
+# ブランチ作成と切り替え
+git checkout -b feature/新機能名
+
+# 変更をステージング
+git add .
+
+# コミット
+git commit -m "feat: 新機能を追加"
+
+# プッシュ
+git push -u origin feature/新機能名
+
+# PR作成（GitHub CLI）
+gh pr create --title "新機能追加" --body "変更内容の説明"
+```
+
+## デバッグとトラブルシューティング
+
+```bash
+# 型チェックのみ実行
+pnpm check-types
+
+# 詳細なlint結果表示
+biome check --verbose
+
+# 特定のファイルのみlint
+biome check src/components/Button.tsx
+
+# Turboの詳細ログ表示
+turbo dev --verbosity=2
+```

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,145 @@
+# トラブルシューティング
+
+このドキュメントでは、よくある問題と解決方法を説明します。
+
+## よくある問題と解決方法
+
+### 型エラー
+
+| 問題 | 解決方法 |
+|------|----------|
+| TypeScript型エラー | `pnpm check-types`で詳細確認 |
+| 型定義が見つからない | `pnpm add -D @types/<package-name>` |
+| 型の競合 | `tsconfig.json`のpathsを確認 |
+
+### 依存関係の問題
+
+| 問題 | 解決方法 |
+|------|----------|
+| 依存関係の競合 | `pnpm install --force` |
+| パッケージが見つからない | `pnpm add <package> --filter=<app>` |
+| バージョンの不整合 | `package.json`でバージョンを固定 |
+
+### キャッシュの問題
+
+| 問題 | 解決方法 |
+|------|----------|
+| ビルドキャッシュの問題 | `turbo daemon clean` |
+| pnpmキャッシュの問題 | `pnpm store prune` |
+| node_modulesの問題 | `rm -rf node_modules && pnpm install` |
+
+### Expo（Native）の問題
+
+| 問題 | 解決方法 |
+|------|----------|
+| Expo環境の問題 | `expo doctor`で環境チェック |
+| iOS Simulatorが起動しない | Xcode設定を確認 |
+| Android Emulatorが起動しない | Android Studioの設定を確認 |
+| Metro bundlerエラー | `expo start --clear` |
+
+### API（Cloudflare Workers）の問題
+
+| 問題 | 解決方法 |
+|------|----------|
+| Wrangler開発サーバーエラー | `cd apps/api && wrangler dev`で詳細確認 |
+| 環境変数が読み込まれない | `.dev.vars`ファイルの存在を確認 |
+| CORSエラー | `wrangler.toml`のCORS設定を確認 |
+| デプロイエラー | Cloudflareアカウント設定を確認 |
+
+### Web（Next.js）の問題
+
+| 問題 | 解決方法 |
+|------|----------|
+| Next.jsビルドエラー | `cd apps/web && pnpm build`で詳細確認 |
+| SSRエラー | `use client`の使用を検討 |
+| 画像の最適化エラー | `next.config.js`の設定を確認 |
+
+### Tamagui（UI）の問題
+
+| 問題 | 解決方法 |
+|------|----------|
+| スタイルが適用されない | Tamaguiプロバイダーの設定を確認 |
+| Web/Nativeでレンダリングが異なる | `@tamagui/core`の設定を確認 |
+| アニメーションが動かない | `@tamagui/animations-react-native`の設定を確認 |
+
+## デバッグ手順
+
+### 1. 基本的なデバッグ
+
+```bash
+# まずは型チェック
+pnpm check-types
+
+# 次にlintチェック
+pnpm fix
+
+# キャッシュクリア
+turbo daemon clean
+
+# 依存関係の再インストール
+pnpm install --force
+```
+
+### 2. アプリ別のデバッグ
+
+#### Web（Next.js）
+```bash
+cd apps/web
+pnpm dev --verbose
+```
+
+#### Native（Expo）
+```bash
+cd apps/native
+expo start --clear
+expo doctor
+```
+
+#### API（Hono）
+```bash
+cd apps/api
+wrangler dev --local
+```
+
+### 3. 詳細なログの確認
+
+```bash
+# Turboの詳細ログ
+turbo dev --verbosity=2
+
+# Biomeの詳細ログ
+biome check --verbose
+
+# pnpmの詳細ログ
+pnpm --reporter=append-only dev
+```
+
+## エラーメッセージ別対処法
+
+### "Module not found"
+1. `pnpm install`を実行
+2. `package.json`でパッケージ名を確認
+3. `tsconfig.json`のpathsを確認
+
+### "Type error"
+1. `pnpm check-types`で詳細確認
+2. 型定義ファイルの存在を確認
+3. `@types/`パッケージの追加を検討
+
+### "Build failed"
+1. `pnpm fix`でコードを修正
+2. 依存関係を最新に更新
+3. キャッシュをクリア
+
+### "Port already in use"
+1. 使用中のポートを確認: `lsof -i :3000`
+2. プロセスを終了: `kill -9 <PID>`
+3. 別のポートを使用: `PORT=3001 pnpm dev`
+
+## 問題が解決しない場合
+
+1. **GitHub Issues**を確認
+2. **ドキュメント**を再読
+3. **依存関係**を最新バージョンに更新
+4. **新しいブランチ**で問題を再現
+5. **Claude Code**に相談


### PR DESCRIPTION
## Summary
- CLAUDE.mdを簡潔にしClaude Code特化の重要情報のみに集約（174行→77行）  
- Tamaguiの記載を追加して最新の構成を反映
- 詳細情報を3つの新しいドキュメントファイルに分離

## 変更内容

### CLAUDE.mdの改善
- 情報量を大幅削減し、Claude Codeが最も必要とする情報に特化
- プロジェクト概要にTamaguiを追加
- 基本コマンドのみを残し、詳細は別ファイルに移動

### 新規作成されたドキュメント
- `docs/API.md`: API環境変数管理とCloudflare Workers設定の詳細
- `docs/COMMANDS.md`: 全てのコマンドの詳細なリファレンス
- `docs/TROUBLESHOOTING.md`: よくある問題と解決方法の体系的なガイド

## Test plan
- [x] CLAUDE.mdが簡潔で必要な情報が揃っていることを確認
- [x] 新しいドキュメントファイルが適切に分類されていることを確認
- [x] リンクが正しく動作することを確認
- [x] Claude Codeが効率的に情報にアクセスできることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)