### PR TITLE
feat: Supabase + Drizzle ORM でTodo APIを実装

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,0 +1,5 @@
+# Supabase Database URL
+# Get this from your Supabase dashboard: Settings > Database > Connection string
+# Use the "Transaction" pooler mode for better performance
+# Format: postgres://postgres.[PROJECT-REF]:[YOUR-PASSWORD]@[REGION].pooler.supabase.com:5432/postgres
+DATABASE_URL=

--- a/apps/api/.gitignore
+++ b/apps/api/.gitignore
@@ -1,0 +1,13 @@
+# Environment variables
+.env
+.env.local
+
+# Wrangler
+.wrangler/
+.dev.vars
+
+# Build output
+dist/
+
+# Logs
+*.log

--- a/apps/api/README-supabase.md
+++ b/apps/api/README-supabase.md
@@ -1,0 +1,206 @@
+# Supabase + Drizzle ORM セットアップガイド
+
+## 概要
+このAPIサーバーは、Supabase PostgreSQLデータベースとDrizzle ORMを使用してTodoリストのCRUD操作を提供します。
+
+## セットアップ手順
+
+### 1. Supabaseプロジェクトの作成
+1. [Supabase](https://supabase.com/)でアカウントを作成
+2. 新しいプロジェクトを作成
+3. データベースパスワードを安全に保管
+
+### 2. データベース接続情報の取得
+1. Supabaseダッシュボード → Settings → Database
+2. Connection string → Connection poolerタブを選択
+3. "Transaction" modeを選択
+4. Connection stringをコピー
+
+### 3. 環境変数の設定
+
+#### ローカル開発用（Wrangler）
+```bash
+# .dev.varsファイルを作成（Cloudflare Workers用）
+echo 'DATABASE_URL="postgres://postgres.[PROJECT-REF]:[YOUR-PASSWORD]@[REGION].pooler.supabase.com:5432/postgres"' > .dev.vars
+```
+
+#### マイグレーション用（Drizzle Kit）
+```bash
+# .envファイルを作成（Drizzle Kit用）
+cp .env.example .env
+
+# DATABASE_URLを設定
+# postgres://postgres.[PROJECT-REF]:[YOUR-PASSWORD]@[REGION].pooler.supabase.com:5432/postgres
+```
+
+### 4. マイグレーションの実行
+```bash
+# マイグレーションファイルを生成
+pnpm db:generate
+
+# マイグレーションを実行
+pnpm db:migrate
+
+# Drizzle Studioでデータベースを確認（オプション）
+pnpm db:studio
+```
+
+### 5. 安全なマイグレーション方針
+- **このプロジェクトでは`pnpm db:migrate`のみを使用**
+- `db:push`は安全性の観点から禁止
+- 全てのスキーマ変更はマイグレーションファイル経由で管理
+- 開発・ステージング・本番環境で同一の方法を使用
+
+### 6. マイグレーションファイルの管理
+- **生成されたマイグレーションファイル**（`drizzle/`フォルダ内）は**Gitで管理します**
+- チーム開発では、スキーマ変更時に必ずマイグレーションファイルをコミット
+- 本番環境では`pnpm db:migrate`でマイグレーションを適用
+
+### 7. Drizzle Studioの使用
+```bash
+# データベース管理UIを起動
+pnpm db:studio
+# ブラウザで https://local.drizzle.studio にアクセス
+```
+
+**Drizzle Studioでできること：**
+- テーブル構造とデータの確認
+- レコードの追加・編集・削除
+- SQLクエリの実行
+- リレーションの可視化
+
+## API エンドポイント
+
+### Todo CRUD操作
+- `GET /api/todos` - 全てのTodoを取得
+- `GET /api/todos/:id` - 特定のTodoを取得
+- `POST /api/todos` - 新しいTodoを作成
+- `PUT /api/todos/:id` - Todoを更新
+- `DELETE /api/todos/:id` - Todoを削除
+
+### リクエスト例
+
+#### Todo作成
+```bash
+curl -X POST http://localhost:8787/api/todos \
+  -H "Content-Type: application/json" \
+  -d '{"title": "買い物に行く", "completed": false}'
+```
+
+#### Todo一覧取得
+```bash
+curl http://localhost:8787/api/todos
+```
+
+#### Todo更新
+```bash
+curl -X PUT http://localhost:8787/api/todos/1 \
+  -H "Content-Type: application/json" \
+  -d '{"completed": true}'
+```
+
+## スキーマ定義
+
+```typescript
+// src/db/schema.ts
+export const todosTable = pgTable('todos', {
+  id: serial('id').primaryKey(),
+  title: text('title').notNull(),
+  completed: boolean('completed').default(false).notNull(),
+  createdAt: timestamp('created_at').notNull().defaultNow(),
+  updatedAt: timestamp('updated_at').notNull().defaultNow().$onUpdate(() => new Date()),
+})
+```
+
+## 注意事項
+
+1. **Connection Pooler**: Supabaseの接続プーラーを使用する場合、`prepare: false`オプションが必要です
+2. **環境変数**: `DATABASE_URL`は必ずバックエンドのみで管理し、フロントエンドに露出させないでください
+3. **CORS設定**: `CORS_ORIGINS`環境変数で許可するオリジンを設定してください
+
+## トラブルシューティング
+
+### データベース接続エラー
+- DATABASE_URLが正しく設定されているか確認
+- Supabaseプロジェクトがアクティブか確認
+- Connection poolerの設定を確認
+
+### マイグレーションエラー
+- Connection Poolerで問題が発生する場合は、Direct Connection URLを使用
+  ```bash
+  # 直接接続の場合（通常は不要）
+  DATABASE_URL="postgres://postgres.[PROJECT-REF]:[YOUR-PASSWORD]@db.[PROJECT-REF].supabase.co:5432/postgres" pnpm db:migrate
+  ```
+
+## npmスクリプト一覧
+
+| コマンド | 説明 |
+| --- | --- |
+| `pnpm db:generate` | マイグレーションファイルを生成 |
+| `pnpm db:migrate` | マイグレーションを実行 |
+| `pnpm db:studio` | Drizzle Studioを起動（データベース管理UI - https://local.drizzle.studio） |
+
+## Hono RPC使用方法
+
+このAPIはHono RPCに対応しており、フロントエンドで型安全なAPIコールが可能です。
+
+### フロントエンド側でのセットアップ
+
+```typescript
+// api-client.ts
+import { hc } from 'hono/client'
+import type { AppType } from '@repo/api/src/app'
+
+const client = hc<AppType>('http://localhost:8787')
+
+// 型安全なAPIコール
+export const api = {
+  todos: {
+    // GET /api/todos
+    getAll: () => client.api.todos.$get(),
+    
+    // GET /api/todos/:id
+    getById: (id: number) => client.api.todos[':id'].$get({ param: { id: id.toString() } }),
+    
+    // POST /api/todos
+    create: (data: { title: string; completed?: boolean }) => 
+      client.api.todos.$post({ json: data }),
+    
+    // PUT /api/todos/:id
+    update: (id: number, data: { title?: string; completed?: boolean }) =>
+      client.api.todos[':id'].$put({ param: { id: id.toString() }, json: data }),
+    
+    // DELETE /api/todos/:id
+    delete: (id: number) => 
+      client.api.todos[':id'].$delete({ param: { id: id.toString() } }),
+  },
+}
+```
+
+### 使用例
+
+```typescript
+// コンポーネント内で使用
+const handleCreateTodo = async () => {
+  const response = await api.todos.create({
+    title: '新しいタスク',
+    completed: false
+  })
+  
+  if (response.ok) {
+    const todo = await response.json()
+    console.log('作成されたTodo:', todo)
+  }
+}
+
+const handleUpdateTodo = async (id: number) => {
+  const response = await api.todos.update(id, {
+    completed: true
+  })
+  
+  if (response.ok) {
+    const updatedTodo = await response.json()
+    console.log('更新されたTodo:', updatedTodo)
+  }
+}
+```

--- a/apps/api/drizzle.config.ts
+++ b/apps/api/drizzle.config.ts
@@ -1,0 +1,14 @@
+import { config } from 'dotenv'
+import { defineConfig } from 'drizzle-kit'
+
+config({ path: '.env' })
+
+export default defineConfig({
+  schema: './src/db/schema.ts',
+  out: './drizzle',
+  dialect: 'postgresql',
+  dbCredentials: {
+    url: process.env.DATABASE_URL || '',
+    ssl: 'require',
+  },
+})

--- a/apps/api/drizzle/0000_faithful_metal_master.sql
+++ b/apps/api/drizzle/0000_faithful_metal_master.sql
@@ -1,0 +1,7 @@
+CREATE TABLE "todos" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"title" text NOT NULL,
+	"completed" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);

--- a/apps/api/drizzle/meta/0000_snapshot.json
+++ b/apps/api/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,65 @@
+{
+  "id": "bc0a769a-3483-4c3a-9030-e8a31d222c6c",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.todos": {
+      "name": "todos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed": {
+          "name": "completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1752876941195,
+      "tag": "0000_faithful_metal_master",
+      "breakpoints": true
+    }
+  ]
+}

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -16,16 +16,24 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "test:ui": "vitest --ui",
-    "test:debug": "vitest --inspect-brk --no-file-parallelism"
+    "test:debug": "vitest --inspect-brk --no-file-parallelism",
+    "db:generate": "drizzle-kit generate",
+    "db:migrate": "drizzle-kit migrate",
+    "db:studio": "drizzle-kit studio"
   },
   "dependencies": {
-    "hono": "4.8.5"
+    "drizzle-orm": "0.44.3",
+    "hono": "4.8.5",
+    "postgres": "3.4.7"
   },
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "0.8.55",
     "@cloudflare/workers-types": "4.20250718.0",
     "@repo/typescript-config": "workspace:*",
     "@types/node": "22.15.3",
+    "@types/pg": "8.15.4",
+    "dotenv": "17.2.0",
+    "drizzle-kit": "0.31.4",
     "typescript": "5.8.2",
     "vitest": "3.2.4",
     "wrangler": "4.25.0"

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,11 +1,12 @@
 import { Hono } from 'hono'
 import { cors } from 'hono/cors'
+import todos from './routes/todos'
 
 export interface Env {
   CORS_ORIGINS?: string
   API_SECRET_KEY?: string
-  DATABASE_URL?: string
-  NODE_ENV?: string
+  DATABASE_URL: string
+  NODE_ENV?: 'development' | 'dev' | 'production' | 'test'
 }
 
 export function createApp() {
@@ -109,6 +110,9 @@ export function createApp() {
     })
   })
 
+  // Todoルートをマウント
+  app.route('/api/todos', todos)
+
   // 404ハンドラー
   app.notFound((c) => {
     return c.json({ error: 'Not Found', path: c.req.path }, 404)
@@ -134,3 +138,5 @@ export function createApp() {
 
   return app
 }
+
+export type AppType = ReturnType<typeof createApp>

--- a/apps/api/src/db/index.ts
+++ b/apps/api/src/db/index.ts
@@ -1,0 +1,22 @@
+import { drizzle } from 'drizzle-orm/postgres-js'
+import postgres from 'postgres'
+import type { Env } from '../app'
+
+// Cloudflare Workersではグローバル変数の使用は推奨されない
+// 各リクエストごとに新しい接続を作成する必要がある
+
+export function getDb(env: Env) {
+  const connectionString = env.DATABASE_URL
+  if (!connectionString) {
+    throw new Error('DATABASE_URL is not set')
+  }
+
+  // Supabase connection pooler requires prepare: false
+  // Cloudflare Workersでは接続プールは自動的に管理される
+  const queryClient = postgres(connectionString, {
+    prepare: false,
+    max: 1, // Cloudflare Workersでは1接続のみ
+  })
+
+  return drizzle({ client: queryClient })
+}

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -1,0 +1,15 @@
+import { boolean, pgTable, serial, text, timestamp } from 'drizzle-orm/pg-core'
+
+export const todosTable = pgTable('todos', {
+  id: serial('id').primaryKey(),
+  title: text('title').notNull(),
+  completed: boolean('completed').default(false).notNull(),
+  createdAt: timestamp('created_at').notNull().defaultNow(),
+  updatedAt: timestamp('updated_at')
+    .notNull()
+    .defaultNow()
+    .$onUpdate(() => new Date()),
+})
+
+export type InsertTodo = typeof todosTable.$inferInsert
+export type SelectTodo = typeof todosTable.$inferSelect

--- a/apps/api/src/routes/todos.ts
+++ b/apps/api/src/routes/todos.ts
@@ -1,0 +1,212 @@
+import { eq } from 'drizzle-orm'
+import { Hono } from 'hono'
+import { validator } from 'hono/validator'
+import type { Env } from '../app'
+import { getDb } from '../db'
+import { todosTable } from '../db/schema'
+
+const todos = new Hono<{ Bindings: Env }>()
+
+// Get all todos
+todos.get('/', async (c) => {
+  try {
+    const db = getDb(c.env)
+    const todos = await db.select().from(todosTable)
+    return c.json(todos)
+  } catch (error) {
+    console.error('Error fetching todos:', error)
+    return c.json({ error: 'Failed to fetch todos' }, 500)
+  }
+})
+
+// Get a single todo by ID
+todos.get(
+  '/:id',
+  validator('param', (value, c) => {
+    const idParam = (value as Record<string, string>).id
+    if (!idParam) {
+      return c.json({ error: 'ID parameter is required' }, 400)
+    }
+    const id = Number.parseInt(idParam)
+    if (Number.isNaN(id) || id <= 0) {
+      return c.json({ error: 'Invalid ID' }, 400)
+    }
+    return { id }
+  }),
+  async (c) => {
+    try {
+      const { id } = c.req.valid('param')
+
+      const db = getDb(c.env)
+      const [todo] = await db.select().from(todosTable).where(eq(todosTable.id, id))
+
+      if (!todo) {
+        return c.json({ error: 'Todo not found' }, 404)
+      }
+
+      return c.json(todo)
+    } catch (error) {
+      console.error('Error fetching todo:', error)
+      return c.json({ error: 'Failed to fetch todo' }, 500)
+    }
+  },
+)
+
+// Create a new todo
+todos.post(
+  '/',
+  validator('json', (value, c) => {
+    if (!value || typeof value !== 'object') {
+      return c.json({ error: 'Invalid JSON' }, 400)
+    }
+
+    const { title, completed } = value as Record<string, unknown>
+
+    if (!title || typeof title !== 'string') {
+      return c.json({ error: 'Title is required and must be a string' }, 400)
+    }
+
+    if (title.trim().length === 0) {
+      return c.json({ error: 'Title cannot be empty' }, 400)
+    }
+
+    if (title.length > 255) {
+      return c.json({ error: 'Title must be 255 characters or less' }, 400)
+    }
+
+    if (completed !== undefined && typeof completed !== 'boolean') {
+      return c.json({ error: 'Completed must be a boolean' }, 400)
+    }
+
+    return {
+      title: title.trim(),
+      completed: completed ?? false,
+    }
+  }),
+  async (c) => {
+    try {
+      const { title, completed } = c.req.valid('json')
+
+      const db = getDb(c.env)
+      const [newTodo] = await db
+        .insert(todosTable)
+        .values({
+          title,
+          completed,
+        })
+        .returning()
+
+      return c.json(newTodo, 201)
+    } catch (error) {
+      console.error('Error creating todo:', error)
+      return c.json({ error: 'Failed to create todo' }, 500)
+    }
+  },
+)
+
+// Update a todo
+todos.put(
+  '/:id',
+  validator('param', (value, c) => {
+    const idParam = (value as Record<string, string>).id
+    if (!idParam) {
+      return c.json({ error: 'ID parameter is required' }, 400)
+    }
+    const id = Number.parseInt(idParam)
+    if (Number.isNaN(id) || id <= 0) {
+      return c.json({ error: 'Invalid ID' }, 400)
+    }
+    return { id }
+  }),
+  validator('json', (value, c) => {
+    if (!value || typeof value !== 'object') {
+      return c.json({ error: 'Invalid JSON' }, 400)
+    }
+
+    const { title, completed } = value as Record<string, unknown>
+
+    if (!title && completed === undefined) {
+      return c.json({ error: 'At least one field (title or completed) is required' }, 400)
+    }
+
+    if (title !== undefined) {
+      if (typeof title !== 'string') {
+        return c.json({ error: 'Title must be a string' }, 400)
+      }
+      if (title.trim().length === 0) {
+        return c.json({ error: 'Title cannot be empty' }, 400)
+      }
+      if (title.length > 255) {
+        return c.json({ error: 'Title must be 255 characters or less' }, 400)
+      }
+    }
+
+    if (completed !== undefined && typeof completed !== 'boolean') {
+      return c.json({ error: 'Completed must be a boolean' }, 400)
+    }
+
+    const updateData: { title?: string; completed?: boolean } = {}
+    if (title !== undefined) updateData.title = title.trim()
+    if (completed !== undefined) updateData.completed = completed
+
+    return updateData
+  }),
+  async (c) => {
+    try {
+      const { id } = c.req.valid('param')
+      const updateData = c.req.valid('json')
+
+      const db = getDb(c.env)
+      const [updatedTodo] = await db
+        .update(todosTable)
+        .set(updateData)
+        .where(eq(todosTable.id, id))
+        .returning()
+
+      if (!updatedTodo) {
+        return c.json({ error: 'Todo not found' }, 404)
+      }
+
+      return c.json(updatedTodo)
+    } catch (error) {
+      console.error('Error updating todo:', error)
+      return c.json({ error: 'Failed to update todo' }, 500)
+    }
+  },
+)
+
+// Delete a todo
+todos.delete(
+  '/:id',
+  validator('param', (value, c) => {
+    const idParam = (value as Record<string, string>).id
+    if (!idParam) {
+      return c.json({ error: 'ID parameter is required' }, 400)
+    }
+    const id = Number.parseInt(idParam)
+    if (Number.isNaN(id) || id <= 0) {
+      return c.json({ error: 'Invalid ID' }, 400)
+    }
+    return { id }
+  }),
+  async (c) => {
+    try {
+      const { id } = c.req.valid('param')
+
+      const db = getDb(c.env)
+      const [deletedTodo] = await db.delete(todosTable).where(eq(todosTable.id, id)).returning()
+
+      if (!deletedTodo) {
+        return c.json({ error: 'Todo not found' }, 404)
+      }
+
+      return c.json({ message: 'Todo deleted successfully', todo: deletedTodo })
+    } catch (error) {
+      console.error('Error deleting todo:', error)
+      return c.json({ error: 'Failed to delete todo' }, 500)
+    }
+  },
+)
+
+export default todos
+export type TodosApp = typeof todos

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -1,11 +1,13 @@
 name = "nextjs-expo-monorepo-api"
 main = "src/index.ts"
 compatibility_date = "2025-07-18"
+compatibility_flags = ["nodejs_compat"]
 
 # ローカル開発用の環境変数
 [vars]
 CORS_ORIGINS = "http://localhost:3000,http://localhost:8081,http://localhost:19006"
 NODE_ENV = "development"
+# DATABASE_URLは.dev.varsまたはwrangler secretで設定
 
 [env.development]
 name = "nextjs-expo-monorepo-api-dev"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,19 +31,43 @@ importers:
 
   apps/api:
     dependencies:
+      drizzle-orm:
+        specifier: 0.44.3
+        version: 0.44.3(@cloudflare/workers-types@4.20250718.0)(@types/pg@8.15.4)(postgres@3.4.7)
       hono:
         specifier: 4.8.5
         version: 4.8.5
+      postgres:
+        specifier: 3.4.7
+        version: 3.4.7
     devDependencies:
+      '@cloudflare/vitest-pool-workers':
+        specifier: 0.8.55
+        version: 0.8.55(@cloudflare/workers-types@4.20250718.0)(@vitest/runner@3.2.4)(@vitest/snapshot@3.2.4)(vitest@3.2.4(@types/node@22.15.3)(jsdom@26.1.0)(lightningcss@1.27.0)(terser@5.43.1))
       '@cloudflare/workers-types':
         specifier: 4.20250718.0
         version: 4.20250718.0
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../packages/typescript-config
+      '@types/node':
+        specifier: 22.15.3
+        version: 22.15.3
+      '@types/pg':
+        specifier: 8.15.4
+        version: 8.15.4
+      dotenv:
+        specifier: 17.2.0
+        version: 17.2.0
+      drizzle-kit:
+        specifier: 0.31.4
+        version: 0.31.4
       typescript:
         specifier: 5.8.2
         version: 5.8.2
+      vitest:
+        specifier: 3.2.4
+        version: 3.2.4(@types/node@22.15.3)(jsdom@26.1.0)(lightningcss@1.27.0)(terser@5.43.1)
       wrangler:
         specifier: 4.25.0
         version: 4.25.0(@cloudflare/workers-types@4.20250718.0)
@@ -841,6 +865,13 @@ packages:
       workerd:
         optional: true
 
+  '@cloudflare/vitest-pool-workers@0.8.55':
+    resolution: {integrity: sha512-3+Saavbg5bauMGmmuSWNID/DXkcag3cyZqP0/vCm7YL1lerygSECFsWlayKok1IA9R+PHnu5U9IbKeOvwB51FA==}
+    peerDependencies:
+      '@vitest/runner': 2.0.x - 3.2.x
+      '@vitest/snapshot': 2.0.x - 3.2.x
+      vitest: 2.0.x - 3.2.x
+
   '@cloudflare/workerd-darwin-64@1.20250712.0':
     resolution: {integrity: sha512-M6S6a/LQ0Jb0R+g0XhlYi1adGifvYmxA5mD/i9TuZZgjs2bIm5ELuka/n3SCnI98ltvlx3HahRaHagAtOilsFg==}
     engines: {node: '>=16'}
@@ -906,6 +937,9 @@ packages:
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
 
+  '@drizzle-team/brocli@0.10.2':
+    resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
+
   '@egjs/hammerjs@2.0.17':
     resolution: {integrity: sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==}
     engines: {node: '>=0.8.0'}
@@ -919,6 +953,14 @@ packages:
   '@emotion/memoize@0.7.4':
     resolution: {integrity: sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==}
 
+  '@esbuild-kit/core-utils@3.3.2':
+    resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
+    deprecated: 'Merged into tsx: https://tsx.is'
+
+  '@esbuild-kit/esm-loader@2.6.5':
+    resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
+    deprecated: 'Merged into tsx: https://tsx.is'
+
   '@esbuild/aix-ppc64@0.25.4':
     resolution: {integrity: sha512-1VCICWypeQKhVbE9oW/sJaAmjLxhVqacdkvPLEjwlttjfwENRSClS8EjBz0KzRyFSCPDIkuXW34Je/vk7zdB7Q==}
     engines: {node: '>=18'}
@@ -931,6 +973,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.18.20':
+    resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.25.4':
     resolution: {integrity: sha512-bBy69pgfhMGtCnwpC/x5QhfxAz/cBgQ9enbtwjf6V9lnPI/hMyT9iWpR1arm0l3kttTr4L0KSLpKmLp/ilKS9A==}
     engines: {node: '>=18'}
@@ -941,6 +989,12 @@ packages:
     resolution: {integrity: sha512-hd5zdUarsK6strW+3Wxi5qWws+rJhCCbMiC9QZyzoxfk5uHRIE8T287giQxzVpEvCwuJ9Qjg6bEjcRJcgfLqoA==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.18.20':
+    resolution: {integrity: sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.25.4':
@@ -955,6 +1009,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.18.20':
+    resolution: {integrity: sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.25.4':
     resolution: {integrity: sha512-TVhdVtQIFuVpIIR282btcGC2oGQoSfZfmBdTip2anCaVYcqWlZXGcdcKIUklfX2wj0JklNYgz39OBqh2cqXvcQ==}
     engines: {node: '>=18'}
@@ -967,6 +1027,12 @@ packages:
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.18.20':
+    resolution: {integrity: sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.25.4':
     resolution: {integrity: sha512-Y1giCfM4nlHDWEfSckMzeWNdQS31BQGs9/rouw6Ub91tkK79aIMTH3q9xHvzH8d0wDru5Ci0kWB8b3up/nl16g==}
     engines: {node: '>=18'}
@@ -977,6 +1043,12 @@ packages:
     resolution: {integrity: sha512-FFCssz3XBavjxcFxKsGy2DYK5VSvJqa6y5HXljKzhRZ87LvEi13brPrf/wdyl/BbpbMKJNOr1Sd0jtW4Ge1pAA==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.18.20':
+    resolution: {integrity: sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.25.4':
@@ -991,6 +1063,12 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.18.20':
+    resolution: {integrity: sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.25.4':
     resolution: {integrity: sha512-yYq+39NlTRzU2XmoPW4l5Ifpl9fqSk0nAJYM/V/WUGPEFfek1epLHJIkTQM6bBs1swApjO5nWgvr843g6TjxuQ==}
     engines: {node: '>=18'}
@@ -1001,6 +1079,12 @@ packages:
     resolution: {integrity: sha512-aoLF2c3OvDn2XDTRvn8hN6DRzVVpDlj2B/F66clWd/FHLiHaG3aVZjxQX2DYphA5y/evbdGvC6Us13tvyt4pWg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.18.20':
+    resolution: {integrity: sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.25.4':
@@ -1015,6 +1099,12 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.18.20':
+    resolution: {integrity: sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.25.4':
     resolution: {integrity: sha512-+89UsQTfXdmjIvZS6nUnOOLoXnkUTB9hR5QAeLrQdzOSWZvNSAXAtcRDHWtqAUtAmv7ZM1WPOOeSxDzzzMogiQ==}
     engines: {node: '>=18'}
@@ -1025,6 +1115,12 @@ packages:
     resolution: {integrity: sha512-b967hU0gqKd9Drsh/UuAm21Khpoh6mPBSgz8mKRq4P5mVK8bpA+hQzmm/ZwGVULSNBzKdZPQBRT3+WuVavcWsQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.18.20':
+    resolution: {integrity: sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.25.4':
@@ -1039,6 +1135,12 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.18.20':
+    resolution: {integrity: sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.25.4':
     resolution: {integrity: sha512-yTEjoapy8UP3rv8dB0ip3AfMpRbyhSN3+hY8mo/i4QXFeDxmiYbEKp3ZRjBKcOP862Ua4b1PDfwlvbuwY7hIGQ==}
     engines: {node: '>=18'}
@@ -1049,6 +1151,12 @@ packages:
     resolution: {integrity: sha512-aHWdQ2AAltRkLPOsKdi3xv0mZ8fUGPdlKEjIEhxCPm5yKEThcUjHpWB1idN74lfXGnZ5SULQSgtr5Qos5B0bPw==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.18.20':
+    resolution: {integrity: sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.25.4':
@@ -1063,6 +1171,12 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.18.20':
+    resolution: {integrity: sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.25.4':
     resolution: {integrity: sha512-IcvTlF9dtLrfL/M8WgNI/qJYBENP3ekgsHbYUIzEzq5XJzzVEV/fXY9WFPfEEXmu3ck2qJP8LG/p3Q8f7Zc2Xg==}
     engines: {node: '>=18'}
@@ -1073,6 +1187,12 @@ packages:
     resolution: {integrity: sha512-WViNlpivRKT9/py3kCmkHnn44GkGXVdXfdc4drNmRl15zVQ2+D2uFwdlGh6IuK5AAnGTo2qPB1Djppj+t78rzw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.18.20':
+    resolution: {integrity: sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.25.4':
@@ -1087,6 +1207,12 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.18.20':
+    resolution: {integrity: sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.25.4':
     resolution: {integrity: sha512-i8JUDAufpz9jOzo4yIShCTcXzS07vEgWzyX3NH2G7LEFVgrLEhjwL3ajFE4fZI3I4ZgiM7JH3GQ7ReObROvSUA==}
     engines: {node: '>=18'}
@@ -1099,6 +1225,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-s390x@0.18.20':
+    resolution: {integrity: sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.25.4':
     resolution: {integrity: sha512-jFnu+6UbLlzIjPQpWCNh5QtrcNfMLjgIavnwPQAfoGx4q17ocOU9MsQ2QVvFxwQoWpZT8DvTLooTvmOQXkO51g==}
     engines: {node: '>=18'}
@@ -1109,6 +1241,12 @@ packages:
     resolution: {integrity: sha512-9N1LsTwAuE9oj6lHMyyAM+ucxGiVnEqUdp4v7IaMmrwb06ZTEVCIs3oPPplVsnjPfyjmxwHxHMF8b6vzUVAUGw==}
     engines: {node: '>=18'}
     cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.18.20':
+    resolution: {integrity: sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [linux]
 
   '@esbuild/linux-x64@0.25.4':
@@ -1135,6 +1273,12 @@ packages:
     cpu: [arm64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.18.20':
+    resolution: {integrity: sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.25.4':
     resolution: {integrity: sha512-XAg8pIQn5CzhOB8odIcAm42QsOfa98SBeKUdo4xa8OvX8LbMZqEtgeWE9P/Wxt7MlG2QqvjGths+nq48TrUiKw==}
     engines: {node: '>=18'}
@@ -1159,6 +1303,12 @@ packages:
     cpu: [arm64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.18.20':
+    resolution: {integrity: sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openbsd-x64@0.25.4':
     resolution: {integrity: sha512-xAGGhyOQ9Otm1Xu8NT1ifGLnA6M3sJxZ6ixylb+vIUVzvvd6GOALpwQrYrtlPouMqd/vSbgehz6HaVk4+7Afhw==}
     engines: {node: '>=18'}
@@ -1177,6 +1327,12 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
+  '@esbuild/sunos-x64@0.18.20':
+    resolution: {integrity: sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/sunos-x64@0.25.4':
     resolution: {integrity: sha512-Mw+tzy4pp6wZEK0+Lwr76pWLjrtjmJyUB23tHKqEDP74R3q95luY/bXqXZeYl4NYlvwOqoRKlInQialgCKy67Q==}
     engines: {node: '>=18'}
@@ -1188,6 +1344,12 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
+
+  '@esbuild/win32-arm64@0.18.20':
+    resolution: {integrity: sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
 
   '@esbuild/win32-arm64@0.25.4':
     resolution: {integrity: sha512-AVUP428VQTSddguz9dO9ngb+E5aScyg7nOeJDrF1HPYu555gmza3bDGMPhmVXL8svDSoqPCsCPjb265yG/kLKQ==}
@@ -1201,6 +1363,12 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.18.20':
+    resolution: {integrity: sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.25.4':
     resolution: {integrity: sha512-i1sW+1i+oWvQzSgfRcxxG2k4I9n3O9NRqy8U+uugaT2Dy7kLO9Y7wI72haOahxceMX8hZAzgGou1FhndRldxRg==}
     engines: {node: '>=18'}
@@ -1211,6 +1379,12 @@ packages:
     resolution: {integrity: sha512-4AWhgXmDuYN7rJI6ORB+uU9DHLq/erBbuMoAuB4VWJTu5KtCgcKYPynF0YI1VkBNuEfjNlLrFr9KZPJzrtLkrQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.18.20':
+    resolution: {integrity: sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.25.4':
@@ -2693,6 +2867,9 @@ packages:
   '@types/node@22.15.3':
     resolution: {integrity: sha512-lX7HFZeHf4QG/J7tBZqrCAXwz9J5RD56Y6MpP0eJkka8p+K0RY/yBTW7CYFJ4VGCclxqOLKmiGP5juQc6MKgcw==}
 
+  '@types/pg@8.15.4':
+    resolution: {integrity: sha512-I6UNVBAoYbvuWkkU3oosC8yxqH21f4/Jc4DK71JLG3dT2mdlGe1z+ep/LQGXaKaOgcvUrsQoPRqfgtMcvZiJhg==}
+
   '@types/react-dom@19.0.0':
     resolution: {integrity: sha512-1KfiQKsH1o00p9m5ag12axHQSb3FOU9H20UTrujVSkNhuCrRHiQWFqgEnTNK5ZNfnzZv8UWrnXVqCmCF9fgY3w==}
 
@@ -3054,6 +3231,9 @@ packages:
   big.js@5.2.2:
     resolution: {integrity: sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==}
 
+  birpc@0.2.14:
+    resolution: {integrity: sha512-37FHE8rqsYM5JEKCnXFyHpBCzvgHEExwVVTq+nUmloInU7l8ezD1TpOhKpS8oe1DTYFqEK27rFZVKG43oTqXRA==}
+
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
@@ -3196,6 +3376,9 @@ packages:
   ci-info@3.9.0:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
     engines: {node: '>=8'}
+
+  cjs-module-lexer@1.4.3:
+    resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
 
   clean-css@5.3.3:
     resolution: {integrity: sha512-D5J+kHaVb/wKSFcyyV75uCn8fiY4sV38XJoe4CUyGQ+mOU/fMVYUdH1hJC+CJQ5uY3EnW27SbJYS4X8BiLrAFg==}
@@ -3465,6 +3648,9 @@ packages:
     resolution: {integrity: sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==}
     engines: {node: '>=8'}
 
+  devalue@4.3.3:
+    resolution: {integrity: sha512-UH8EL6H2ifcY8TbD2QsxwCC/pr5xSwPvv85LrLXVihmHVC3T3YqTCIwnR5ak0yO1KYqlxrPVOA/JVZJYPy2ATg==}
+
   diff@4.0.2:
     resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
     engines: {node: '>=0.3.1'}
@@ -3508,6 +3694,106 @@ packages:
   dotenv@16.4.7:
     resolution: {integrity: sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==}
     engines: {node: '>=12'}
+
+  dotenv@17.2.0:
+    resolution: {integrity: sha512-Q4sgBT60gzd0BB0lSyYD3xM4YxrXA9y4uBDof1JNYGzOXrQdQ6yX+7XIAqoFOGQFOTK1D3Hts5OllpxMDZFONQ==}
+    engines: {node: '>=12'}
+
+  drizzle-kit@0.31.4:
+    resolution: {integrity: sha512-tCPWVZWZqWVx2XUsVpJRnH9Mx0ClVOf5YUHerZ5so1OKSlqww4zy1R5ksEdGRcO3tM3zj0PYN6V48TbQCL1RfA==}
+    hasBin: true
+
+  drizzle-orm@0.44.3:
+    resolution: {integrity: sha512-8nIiYQxOpgUicEL04YFojJmvC4DNO4KoyXsEIqN44+g6gNBr6hmVpWk3uyAt4CaTiRGDwoU+alfqNNeonLAFOQ==}
+    peerDependencies:
+      '@aws-sdk/client-rds-data': '>=3'
+      '@cloudflare/workers-types': '>=4'
+      '@electric-sql/pglite': '>=0.2.0'
+      '@libsql/client': '>=0.10.0'
+      '@libsql/client-wasm': '>=0.10.0'
+      '@neondatabase/serverless': '>=0.10.0'
+      '@op-engineering/op-sqlite': '>=2'
+      '@opentelemetry/api': ^1.4.1
+      '@planetscale/database': '>=1.13'
+      '@prisma/client': '*'
+      '@tidbcloud/serverless': '*'
+      '@types/better-sqlite3': '*'
+      '@types/pg': '*'
+      '@types/sql.js': '*'
+      '@upstash/redis': '>=1.34.7'
+      '@vercel/postgres': '>=0.8.0'
+      '@xata.io/client': '*'
+      better-sqlite3: '>=7'
+      bun-types: '*'
+      expo-sqlite: '>=14.0.0'
+      gel: '>=2'
+      knex: '*'
+      kysely: '*'
+      mysql2: '>=2'
+      pg: '>=8'
+      postgres: '>=3'
+      prisma: '*'
+      sql.js: '>=1'
+      sqlite3: '>=5'
+    peerDependenciesMeta:
+      '@aws-sdk/client-rds-data':
+        optional: true
+      '@cloudflare/workers-types':
+        optional: true
+      '@electric-sql/pglite':
+        optional: true
+      '@libsql/client':
+        optional: true
+      '@libsql/client-wasm':
+        optional: true
+      '@neondatabase/serverless':
+        optional: true
+      '@op-engineering/op-sqlite':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@planetscale/database':
+        optional: true
+      '@prisma/client':
+        optional: true
+      '@tidbcloud/serverless':
+        optional: true
+      '@types/better-sqlite3':
+        optional: true
+      '@types/pg':
+        optional: true
+      '@types/sql.js':
+        optional: true
+      '@upstash/redis':
+        optional: true
+      '@vercel/postgres':
+        optional: true
+      '@xata.io/client':
+        optional: true
+      better-sqlite3:
+        optional: true
+      bun-types:
+        optional: true
+      expo-sqlite:
+        optional: true
+      gel:
+        optional: true
+      knex:
+        optional: true
+      kysely:
+        optional: true
+      mysql2:
+        optional: true
+      pg:
+        optional: true
+      postgres:
+        optional: true
+      prisma:
+        optional: true
+      sql.js:
+        optional: true
+      sqlite3:
+        optional: true
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
@@ -3575,6 +3861,11 @@ packages:
     resolution: {integrity: sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==}
     peerDependencies:
       esbuild: '>=0.12 <1'
+
+  esbuild@0.18.20:
+    resolution: {integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==}
+    engines: {node: '>=12'}
+    hasBin: true
 
   esbuild@0.25.4:
     resolution: {integrity: sha512-8pgjLUcUjcgDg+2Q4NYXnPbo/vncAY4UmyaCm0jZevERqCHZIaWwdJHkf8XQtu4AxSKCdvrUbT0XUr1IdZzI8Q==}
@@ -5011,6 +5302,17 @@ packages:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
 
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-protocol@1.10.3:
+    resolution: {integrity: sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
   picocolors@1.0.1:
     resolution: {integrity: sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==}
 
@@ -5104,6 +5406,26 @@ packages:
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
+
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-bytea@1.0.0:
+    resolution: {integrity: sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres@3.4.7:
+    resolution: {integrity: sha512-Jtc2612XINuBjIl/QTWsV5UvE8UHuNblcO3vVADSrKsrc6RqGX6lOW1cEo3CM2v0XG4Nat8nI+YM7/f26VxXLw==}
+    engines: {node: '>=12'}
 
   pretty-bytes@5.6.0:
     resolution: {integrity: sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==}
@@ -6325,6 +6647,10 @@ packages:
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
+
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -7035,6 +7361,23 @@ snapshots:
     optionalDependencies:
       workerd: 1.20250712.0
 
+  '@cloudflare/vitest-pool-workers@0.8.55(@cloudflare/workers-types@4.20250718.0)(@vitest/runner@3.2.4)(@vitest/snapshot@3.2.4)(vitest@3.2.4(@types/node@22.15.3)(jsdom@26.1.0)(lightningcss@1.27.0)(terser@5.43.1))':
+    dependencies:
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      birpc: 0.2.14
+      cjs-module-lexer: 1.4.3
+      devalue: 4.3.3
+      miniflare: 4.20250712.0
+      semver: 7.7.2
+      vitest: 3.2.4(@types/node@22.15.3)(jsdom@26.1.0)(lightningcss@1.27.0)(terser@5.43.1)
+      wrangler: 4.25.0(@cloudflare/workers-types@4.20250718.0)
+      zod: 3.22.3
+    transitivePeerDependencies:
+      - '@cloudflare/workers-types'
+      - bufferutil
+      - utf-8-validate
+
   '@cloudflare/workerd-darwin-64@1.20250712.0':
     optional: true
 
@@ -7076,6 +7419,8 @@ snapshots:
 
   '@csstools/css-tokenizer@3.0.4': {}
 
+  '@drizzle-team/brocli@0.10.2': {}
+
   '@egjs/hammerjs@2.0.17':
     dependencies:
       '@types/hammerjs': 2.0.46
@@ -7093,10 +7438,23 @@ snapshots:
   '@emotion/memoize@0.7.4':
     optional: true
 
+  '@esbuild-kit/core-utils@3.3.2':
+    dependencies:
+      esbuild: 0.18.20
+      source-map-support: 0.5.21
+
+  '@esbuild-kit/esm-loader@2.6.5':
+    dependencies:
+      '@esbuild-kit/core-utils': 3.3.2
+      get-tsconfig: 4.10.1
+
   '@esbuild/aix-ppc64@0.25.4':
     optional: true
 
   '@esbuild/aix-ppc64@0.25.6':
+    optional: true
+
+  '@esbuild/android-arm64@0.18.20':
     optional: true
 
   '@esbuild/android-arm64@0.25.4':
@@ -7105,10 +7463,16 @@ snapshots:
   '@esbuild/android-arm64@0.25.6':
     optional: true
 
+  '@esbuild/android-arm@0.18.20':
+    optional: true
+
   '@esbuild/android-arm@0.25.4':
     optional: true
 
   '@esbuild/android-arm@0.25.6':
+    optional: true
+
+  '@esbuild/android-x64@0.18.20':
     optional: true
 
   '@esbuild/android-x64@0.25.4':
@@ -7117,10 +7481,16 @@ snapshots:
   '@esbuild/android-x64@0.25.6':
     optional: true
 
+  '@esbuild/darwin-arm64@0.18.20':
+    optional: true
+
   '@esbuild/darwin-arm64@0.25.4':
     optional: true
 
   '@esbuild/darwin-arm64@0.25.6':
+    optional: true
+
+  '@esbuild/darwin-x64@0.18.20':
     optional: true
 
   '@esbuild/darwin-x64@0.25.4':
@@ -7129,10 +7499,16 @@ snapshots:
   '@esbuild/darwin-x64@0.25.6':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.18.20':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.25.4':
     optional: true
 
   '@esbuild/freebsd-arm64@0.25.6':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.18.20':
     optional: true
 
   '@esbuild/freebsd-x64@0.25.4':
@@ -7141,10 +7517,16 @@ snapshots:
   '@esbuild/freebsd-x64@0.25.6':
     optional: true
 
+  '@esbuild/linux-arm64@0.18.20':
+    optional: true
+
   '@esbuild/linux-arm64@0.25.4':
     optional: true
 
   '@esbuild/linux-arm64@0.25.6':
+    optional: true
+
+  '@esbuild/linux-arm@0.18.20':
     optional: true
 
   '@esbuild/linux-arm@0.25.4':
@@ -7153,10 +7535,16 @@ snapshots:
   '@esbuild/linux-arm@0.25.6':
     optional: true
 
+  '@esbuild/linux-ia32@0.18.20':
+    optional: true
+
   '@esbuild/linux-ia32@0.25.4':
     optional: true
 
   '@esbuild/linux-ia32@0.25.6':
+    optional: true
+
+  '@esbuild/linux-loong64@0.18.20':
     optional: true
 
   '@esbuild/linux-loong64@0.25.4':
@@ -7165,10 +7553,16 @@ snapshots:
   '@esbuild/linux-loong64@0.25.6':
     optional: true
 
+  '@esbuild/linux-mips64el@0.18.20':
+    optional: true
+
   '@esbuild/linux-mips64el@0.25.4':
     optional: true
 
   '@esbuild/linux-mips64el@0.25.6':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.18.20':
     optional: true
 
   '@esbuild/linux-ppc64@0.25.4':
@@ -7177,16 +7571,25 @@ snapshots:
   '@esbuild/linux-ppc64@0.25.6':
     optional: true
 
+  '@esbuild/linux-riscv64@0.18.20':
+    optional: true
+
   '@esbuild/linux-riscv64@0.25.4':
     optional: true
 
   '@esbuild/linux-riscv64@0.25.6':
     optional: true
 
+  '@esbuild/linux-s390x@0.18.20':
+    optional: true
+
   '@esbuild/linux-s390x@0.25.4':
     optional: true
 
   '@esbuild/linux-s390x@0.25.6':
+    optional: true
+
+  '@esbuild/linux-x64@0.18.20':
     optional: true
 
   '@esbuild/linux-x64@0.25.4':
@@ -7201,6 +7604,9 @@ snapshots:
   '@esbuild/netbsd-arm64@0.25.6':
     optional: true
 
+  '@esbuild/netbsd-x64@0.18.20':
+    optional: true
+
   '@esbuild/netbsd-x64@0.25.4':
     optional: true
 
@@ -7213,6 +7619,9 @@ snapshots:
   '@esbuild/openbsd-arm64@0.25.6':
     optional: true
 
+  '@esbuild/openbsd-x64@0.18.20':
+    optional: true
+
   '@esbuild/openbsd-x64@0.25.4':
     optional: true
 
@@ -7222,10 +7631,16 @@ snapshots:
   '@esbuild/openharmony-arm64@0.25.6':
     optional: true
 
+  '@esbuild/sunos-x64@0.18.20':
+    optional: true
+
   '@esbuild/sunos-x64@0.25.4':
     optional: true
 
   '@esbuild/sunos-x64@0.25.6':
+    optional: true
+
+  '@esbuild/win32-arm64@0.18.20':
     optional: true
 
   '@esbuild/win32-arm64@0.25.4':
@@ -7234,10 +7649,16 @@ snapshots:
   '@esbuild/win32-arm64@0.25.6':
     optional: true
 
+  '@esbuild/win32-ia32@0.18.20':
+    optional: true
+
   '@esbuild/win32-ia32@0.25.4':
     optional: true
 
   '@esbuild/win32-ia32@0.25.6':
+    optional: true
+
+  '@esbuild/win32-x64@0.18.20':
     optional: true
 
   '@esbuild/win32-x64@0.25.4':
@@ -9562,6 +9983,12 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/pg@8.15.4':
+    dependencies:
+      '@types/node': 22.15.3
+      pg-protocol: 1.10.3
+      pg-types: 2.2.0
+
   '@types/react-dom@19.0.0':
     dependencies:
       '@types/react': 19.0.10
@@ -10002,6 +10429,8 @@ snapshots:
 
   big.js@5.2.2: {}
 
+  birpc@0.2.14: {}
+
   bl@4.1.0:
     dependencies:
       buffer: 5.7.1
@@ -10179,6 +10608,8 @@ snapshots:
   ci-info@2.0.0: {}
 
   ci-info@3.9.0: {}
+
+  cjs-module-lexer@1.4.3: {}
 
   clean-css@5.3.3:
     dependencies:
@@ -10417,6 +10848,8 @@ snapshots:
 
   detect-libc@2.0.4: {}
 
+  devalue@4.3.3: {}
+
   diff@4.0.2: {}
 
   dir-glob@3.0.1:
@@ -10463,6 +10896,23 @@ snapshots:
       dotenv: 16.4.7
 
   dotenv@16.4.7: {}
+
+  dotenv@17.2.0: {}
+
+  drizzle-kit@0.31.4:
+    dependencies:
+      '@drizzle-team/brocli': 0.10.2
+      '@esbuild-kit/esm-loader': 2.6.5
+      esbuild: 0.25.6
+      esbuild-register: 3.6.0(esbuild@0.25.6)
+    transitivePeerDependencies:
+      - supports-color
+
+  drizzle-orm@0.44.3(@cloudflare/workers-types@4.20250718.0)(@types/pg@8.15.4)(postgres@3.4.7):
+    optionalDependencies:
+      '@cloudflare/workers-types': 4.20250718.0
+      '@types/pg': 8.15.4
+      postgres: 3.4.7
 
   eastasianwidth@0.2.0: {}
 
@@ -10525,6 +10975,31 @@ snapshots:
       esbuild: 0.25.6
     transitivePeerDependencies:
       - supports-color
+
+  esbuild@0.18.20:
+    optionalDependencies:
+      '@esbuild/android-arm': 0.18.20
+      '@esbuild/android-arm64': 0.18.20
+      '@esbuild/android-x64': 0.18.20
+      '@esbuild/darwin-arm64': 0.18.20
+      '@esbuild/darwin-x64': 0.18.20
+      '@esbuild/freebsd-arm64': 0.18.20
+      '@esbuild/freebsd-x64': 0.18.20
+      '@esbuild/linux-arm': 0.18.20
+      '@esbuild/linux-arm64': 0.18.20
+      '@esbuild/linux-ia32': 0.18.20
+      '@esbuild/linux-loong64': 0.18.20
+      '@esbuild/linux-mips64el': 0.18.20
+      '@esbuild/linux-ppc64': 0.18.20
+      '@esbuild/linux-riscv64': 0.18.20
+      '@esbuild/linux-s390x': 0.18.20
+      '@esbuild/linux-x64': 0.18.20
+      '@esbuild/netbsd-x64': 0.18.20
+      '@esbuild/openbsd-x64': 0.18.20
+      '@esbuild/sunos-x64': 0.18.20
+      '@esbuild/win32-arm64': 0.18.20
+      '@esbuild/win32-ia32': 0.18.20
+      '@esbuild/win32-x64': 0.18.20
 
   esbuild@0.25.4:
     optionalDependencies:
@@ -12202,6 +12677,18 @@ snapshots:
 
   pathval@2.0.1: {}
 
+  pg-int8@1.0.1: {}
+
+  pg-protocol@1.10.3: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.0
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
   picocolors@1.0.1: {}
 
   picocolors@1.1.1: {}
@@ -12290,6 +12777,18 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.0: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
+
+  postgres@3.4.7: {}
 
   pretty-bytes@5.6.0: {}
 
@@ -13641,6 +14140,8 @@ snapshots:
   xmlbuilder@15.1.1: {}
 
   xmlchars@2.2.0: {}
+
+  xtend@4.0.2: {}
 
   y18n@5.0.8: {}
 


### PR DESCRIPTION
## 概要

Supabase PostgreSQLデータベースとDrizzle ORMを使用したTodo APIの実装を追加しました。
型安全なHono RPCに対応したCRUD操作を提供し、フロントエンドからの安全なAPI利用が可能です。

## 主な変更

### 📦 パッケージ追加
- `drizzle-orm@0.44.3` - TypeScript ORM
- `postgres@3.4.7` - PostgreSQL クライアント
- `drizzle-kit@0.31.4` - マイグレーション管理ツール

### 🗃️ データベース設定
- **スキーマ定義**: `src/db/schema.ts` でTodoテーブルを定義
- **データベース接続**: Cloudflare Workers対応の接続設定
- **マイグレーション**: 安全なマイグレーション管理（`db:push`禁止）

### 🚀 API実装
- **Todo CRUD API**: 完全なCRUD操作のエンドポイント
- **Hono RPC対応**: 型安全なAPI呼び出しをサポート
- **バリデーション**: リクエストパラメータの厳密なバリデーション

### 🔧 設定更新
- **Wrangler設定**: `nodejs_compat`フラグ追加でpostgresパッケージに対応
- **環境変数**: `.env`と`.dev.vars`でローカル・本番環境対応
- **npmスクリプト**: データベース操作用コマンドを追加

### 📚 ドキュメント
- **セットアップガイド**: `README-supabase.md`で詳細な導入手順を記載
- **API仕様**: エンドポイントとリクエスト例を文書化
- **Hono RPC使用例**: フロントエンド側での型安全なAPI利用方法

## APIエンドポイント

| メソッド | エンドポイント | 説明 |
|---------|---------------|------|
| GET | `/api/todos` | 全Todoを取得 |
| GET | `/api/todos/:id` | 特定のTodoを取得 |
| POST | `/api/todos` | 新しいTodoを作成 |
| PUT | `/api/todos/:id` | Todoを更新 |
| DELETE | `/api/todos/:id` | Todoを削除 |

## セットアップ手順

1. **Supabaseプロジェクト作成**: [supabase.com](https://supabase.com/)でプロジェクト作成
2. **環境変数設定**: `DATABASE_URL`を`.dev.vars`と`.env`に設定
3. **マイグレーション実行**: `pnpm db:generate && pnpm db:migrate`
4. **開発サーバー起動**: `pnpm dev:api`

## テスト

```bash
# API動作確認
curl -X POST http://localhost:8787/api/todos \
  -H "Content-Type: application/json" \
  -d '{"title": "テストタスク", "completed": false}'

curl http://localhost:8787/api/todos
```

## 技術仕様

- **データベース**: Supabase PostgreSQL（Connection Pooler使用）
- **ORM**: Drizzle ORM（TypeScript ファースト）
- **API**: Hono RPC（型安全）
- **デプロイ**: Cloudflare Workers
- **マイグレーション**: drizzle-kit（バージョン管理）

🤖 Generated with [Claude Code](https://claude.ai/code)