### PR TITLE
refactor: todosファイル構造の整理と責務分離

### DIFF
--- a/apps/api/src/routes/todos.ts
+++ b/apps/api/src/routes/todos.ts
@@ -1,298 +1,35 @@
 import { zValidator } from '@hono/zod-validator'
-import { eq } from 'drizzle-orm'
 import { Hono } from 'hono'
-import { z } from 'zod'
 import type { Env } from '../app'
-import { getDb } from '../db'
-import { todosTable } from '../db/schema'
-
-// Zod schemas for validation
-const ParamSchema = z.object({
-  id: z
-    .string()
-    .regex(/^\d+$/, 'Invalid ID format')
-    .transform((val) => Number.parseInt(val, 10))
-    .refine((val) => val > 0, 'ID must be positive'),
-})
-
-const CreateTodoSchema = z.object({
-  title: z
-    .string()
-    .trim()
-    .min(1, 'Title cannot be empty')
-    .max(255, 'Title must be 255 characters or less'),
-  completed: z.boolean().default(false),
-})
-
-const UpdateTodoSchema = z
-  .object({
-    title: z
-      .string()
-      .trim()
-      .min(1, 'Title cannot be empty')
-      .max(255, 'Title must be 255 characters or less')
-      .optional(),
-    completed: z.boolean().optional(),
-  })
-  .refine(
-    (data) => data.title !== undefined || data.completed !== undefined,
-    'At least one field (title or completed) is required',
-  )
-
-// Custom error handlers for backward compatibility with tests
-// Using explicit function declarations to avoid complex type constraints
-// biome-ignore lint/suspicious/noExplicitAny: zValidator Hook type is complex
-function handleParamValidationError(result: any, c: any) {
-  if (!result.success) {
-    return c.json({ error: 'Invalid ID' }, 400)
-  }
-}
-
-// biome-ignore lint/suspicious/noExplicitAny: zValidator Hook type is complex
-function handleCreateTodoError(result: any, c: any) {
-  if (!result.success) {
-    const issues = result.error?.issues || []
-    const firstIssue = issues[0]
-
-    if (!firstIssue) {
-      return c.json({ error: 'Invalid JSON' }, 400)
-    }
-
-    // Handle missing required field (title)
-    if (
-      firstIssue.code === 'invalid_type' &&
-      firstIssue.expected === 'string' &&
-      firstIssue.received === 'undefined' &&
-      firstIssue.path?.[0] === 'title'
-    ) {
-      return c.json({ error: 'Title is required and must be a string' }, 400)
-    }
-
-    // Handle wrong type for title
-    if (
-      firstIssue.code === 'invalid_type' &&
-      firstIssue.expected === 'string' &&
-      firstIssue.path?.[0] === 'title'
-    ) {
-      return c.json({ error: 'Title is required and must be a string' }, 400)
-    }
-
-    // Handle title validation errors
-    if (firstIssue?.path?.[0] === 'title') {
-      if (firstIssue.code === 'too_small') {
-        return c.json({ error: 'Title cannot be empty' }, 400)
-      }
-      if (firstIssue.code === 'too_big') {
-        return c.json({ error: 'Title must be 255 characters or less' }, 400)
-      }
-    }
-
-    // Handle completed field errors
-    if (firstIssue?.path?.[0] === 'completed' && firstIssue.code === 'invalid_type') {
-      return c.json({ error: 'Completed must be a boolean' }, 400)
-    }
-
-    return c.json({ error: 'Invalid JSON' }, 400)
-  }
-}
-
-// biome-ignore lint/suspicious/noExplicitAny: zValidator Hook type is complex
-function handleUpdateTodoError(result: any, c: any) {
-  if (!result.success) {
-    const issues = result.error?.issues || []
-    const firstIssue = issues[0]
-
-    if (!firstIssue) {
-      return c.json({ error: 'Validation failed' }, 400)
-    }
-
-    if (firstIssue?.message === 'At least one field (title or completed) is required') {
-      return c.json({ error: 'At least one field (title or completed) is required' }, 400)
-    }
-    if (firstIssue?.path?.[0] === 'title') {
-      if (firstIssue.code === 'too_small') {
-        return c.json({ error: 'Title cannot be empty' }, 400)
-      }
-      if (firstIssue.code === 'too_big') {
-        return c.json({ error: 'Title must be 255 characters or less' }, 400)
-      }
-      if (firstIssue.code === 'invalid_type') {
-        return c.json({ error: 'Title must be a string' }, 400)
-      }
-      return c.json({ error: 'Title must be a string' }, 400)
-    }
-    if (firstIssue?.path?.[0] === 'completed') {
-      return c.json({ error: 'Completed must be a boolean' }, 400)
-    }
-    return c.json({ error: 'Validation failed' }, 400)
-  }
-}
-
-// テスト環境でのモックDB使用のため
-async function getMockDb() {
-  // 動的インポートでテストヘルパーを取得（テスト環境でのみ利用可能）
-  try {
-    const { mockDb } = await import('../../tests/utils/test-helpers')
-    return mockDb
-  } catch {
-    return null
-  }
-}
-
-function isTestEnvironment(env: Env): boolean {
-  return env.DATABASE_URL?.startsWith('mock://') ?? false
-}
+import { createTodo, deleteTodo, getAllTodos, getTodoById, updateTodo } from '../todos/handlers'
+import { CreateTodoSchema, ParamSchema, UpdateTodoSchema } from '../todos/schema'
+import {
+  handleCreateTodoError,
+  handleParamValidationError,
+  handleUpdateTodoError,
+} from '../todos/validation'
 
 const todos = new Hono<{ Bindings: Env }>()
 
 // Get all todos
-todos.get('/', async (c) => {
-  try {
-    if (isTestEnvironment(c.env)) {
-      const mockDb = await getMockDb()
-      if (mockDb) {
-        const todos = await mockDb.getAllTodos()
-        return c.json(todos)
-      }
-    }
-
-    const db = getDb(c.env)
-    const todos = await db.select().from(todosTable)
-    return c.json(todos)
-  } catch (error) {
-    console.error('Error fetching todos:', error)
-    return c.json({ error: 'Failed to fetch todos' }, 500)
-  }
-})
+todos.get('/', getAllTodos)
 
 // Get a single todo by ID
-todos.get('/:id', zValidator('param', ParamSchema, handleParamValidationError), async (c) => {
-  try {
-    const { id } = c.req.valid('param')
-
-    if (isTestEnvironment(c.env)) {
-      const mockDb = await getMockDb()
-      if (mockDb) {
-        const todo = await mockDb.getTodoById(id)
-        if (!todo) {
-          return c.json({ error: 'Todo not found' }, 404)
-        }
-        return c.json(todo)
-      }
-    }
-
-    const db = getDb(c.env)
-    const [todo] = await db.select().from(todosTable).where(eq(todosTable.id, id))
-
-    if (!todo) {
-      return c.json({ error: 'Todo not found' }, 404)
-    }
-
-    return c.json(todo)
-  } catch (error) {
-    console.error('Error fetching todo:', error)
-    return c.json({ error: 'Failed to fetch todo' }, 500)
-  }
-})
+todos.get('/:id', zValidator('param', ParamSchema, handleParamValidationError), getTodoById)
 
 // Create a new todo
-todos.post('/', zValidator('json', CreateTodoSchema, handleCreateTodoError), async (c) => {
-  try {
-    const { title, completed } = c.req.valid('json')
-
-    if (isTestEnvironment(c.env)) {
-      const mockDb = await getMockDb()
-      if (mockDb) {
-        const newTodo = await mockDb.createTodo({ title, completed })
-        return c.json(newTodo, 201)
-      }
-    }
-
-    const db = getDb(c.env)
-    const [newTodo] = await db
-      .insert(todosTable)
-      .values({
-        title,
-        completed,
-      })
-      .returning()
-
-    return c.json(newTodo, 201)
-  } catch (error) {
-    console.error('Error creating todo:', error)
-    return c.json({ error: 'Failed to create todo' }, 500)
-  }
-})
+todos.post('/', zValidator('json', CreateTodoSchema, handleCreateTodoError), createTodo)
 
 // Update a todo
 todos.put(
   '/:id',
   zValidator('param', ParamSchema, handleParamValidationError),
   zValidator('json', UpdateTodoSchema, handleUpdateTodoError),
-  async (c) => {
-    try {
-      const { id } = c.req.valid('param')
-      const updateData = c.req.valid('json')
-
-      if (isTestEnvironment(c.env)) {
-        const mockDb = await getMockDb()
-        if (mockDb) {
-          const updatedTodo = await mockDb.updateTodo(id, updateData)
-          if (!updatedTodo) {
-            return c.json({ error: 'Todo not found' }, 404)
-          }
-          return c.json(updatedTodo)
-        }
-      }
-
-      const db = getDb(c.env)
-      const [updatedTodo] = await db
-        .update(todosTable)
-        .set(updateData)
-        .where(eq(todosTable.id, id))
-        .returning()
-
-      if (!updatedTodo) {
-        return c.json({ error: 'Todo not found' }, 404)
-      }
-
-      return c.json(updatedTodo)
-    } catch (error) {
-      console.error('Error updating todo:', error)
-      return c.json({ error: 'Failed to update todo' }, 500)
-    }
-  },
+  updateTodo,
 )
 
 // Delete a todo
-todos.delete('/:id', zValidator('param', ParamSchema, handleParamValidationError), async (c) => {
-  try {
-    const { id } = c.req.valid('param')
-
-    if (isTestEnvironment(c.env)) {
-      const mockDb = await getMockDb()
-      if (mockDb) {
-        const deleted = await mockDb.deleteTodo(id)
-        if (!deleted) {
-          return c.json({ error: 'Todo not found' }, 404)
-        }
-        return c.json({ message: 'Todo deleted successfully' })
-      }
-    }
-
-    const db = getDb(c.env)
-    const [deletedTodo] = await db.delete(todosTable).where(eq(todosTable.id, id)).returning()
-
-    if (!deletedTodo) {
-      return c.json({ error: 'Todo not found' }, 404)
-    }
-
-    return c.json({ message: 'Todo deleted successfully', todo: deletedTodo })
-  } catch (error) {
-    console.error('Error deleting todo:', error)
-    return c.json({ error: 'Failed to delete todo' }, 500)
-  }
-})
+todos.delete('/:id', zValidator('param', ParamSchema, handleParamValidationError), deleteTodo)
 
 export default todos
 export type TodosApp = typeof todos

--- a/apps/api/src/todos/handlers.ts
+++ b/apps/api/src/todos/handlers.ts
@@ -1,0 +1,164 @@
+import { eq } from 'drizzle-orm'
+import type { Context } from 'hono'
+import type { Env } from '../app'
+import { getDb } from '../db'
+import { todosTable } from '../db/schema'
+import type { CreateTodoType, ParamType, UpdateTodoType } from './schema'
+
+// テスト用のモックDB関数をインポート（本番では使用されない）
+async function getMockDb() {
+  try {
+    const { getMockDb: getTestMockDb } = await import('../../tests/mock-database')
+    return await getTestMockDb()
+  } catch {
+    return null
+  }
+}
+
+function isTestEnvironment(env: Env): boolean {
+  return env.DATABASE_URL?.startsWith('mock://') ?? false
+}
+
+export async function getAllTodos(c: Context<{ Bindings: Env }>) {
+  try {
+    if (isTestEnvironment(c.env)) {
+      const mockDb = await getMockDb()
+      if (mockDb) {
+        const todos = await mockDb.getAllTodos()
+        return c.json(todos)
+      }
+    }
+
+    const db = getDb(c.env)
+    const todos = await db.select().from(todosTable)
+    return c.json(todos)
+  } catch (error) {
+    console.error('Error fetching todos:', error)
+    return c.json({ error: 'Failed to fetch todos' }, 500)
+  }
+}
+
+export async function getTodoById(c: Context<{ Bindings: Env }>) {
+  try {
+    // biome-ignore lint/suspicious/noExplicitAny: Hono zValidator typing issue
+    const { id } = (c.req as any).valid('param') as ParamType
+
+    if (isTestEnvironment(c.env)) {
+      const mockDb = await getMockDb()
+      if (mockDb) {
+        const todo = await mockDb.getTodoById(id)
+        if (!todo) {
+          return c.json({ error: 'Todo not found' }, 404)
+        }
+        return c.json(todo)
+      }
+    }
+
+    const db = getDb(c.env)
+    const [todo] = await db.select().from(todosTable).where(eq(todosTable.id, id))
+
+    if (!todo) {
+      return c.json({ error: 'Todo not found' }, 404)
+    }
+
+    return c.json(todo)
+  } catch (error) {
+    console.error('Error fetching todo:', error)
+    return c.json({ error: 'Failed to fetch todo' }, 500)
+  }
+}
+
+export async function createTodo(c: Context<{ Bindings: Env }>) {
+  try {
+    // biome-ignore lint/suspicious/noExplicitAny: Hono zValidator typing issue
+    const { title, completed } = (c.req as any).valid('json') as CreateTodoType
+
+    if (isTestEnvironment(c.env)) {
+      const mockDb = await getMockDb()
+      if (mockDb) {
+        const newTodo = await mockDb.createTodo({ title, completed })
+        return c.json(newTodo, 201)
+      }
+    }
+
+    const db = getDb(c.env)
+    const [newTodo] = await db
+      .insert(todosTable)
+      .values({
+        title,
+        completed,
+      })
+      .returning()
+
+    return c.json(newTodo, 201)
+  } catch (error) {
+    console.error('Error creating todo:', error)
+    return c.json({ error: 'Failed to create todo' }, 500)
+  }
+}
+
+export async function updateTodo(c: Context<{ Bindings: Env }>) {
+  try {
+    // biome-ignore lint/suspicious/noExplicitAny: Hono zValidator typing issue
+    const { id } = (c.req as any).valid('param') as ParamType
+    // biome-ignore lint/suspicious/noExplicitAny: Hono zValidator typing issue
+    const updateData = (c.req as any).valid('json') as UpdateTodoType
+
+    if (isTestEnvironment(c.env)) {
+      const mockDb = await getMockDb()
+      if (mockDb) {
+        const updatedTodo = await mockDb.updateTodo(id, updateData)
+        if (!updatedTodo) {
+          return c.json({ error: 'Todo not found' }, 404)
+        }
+        return c.json(updatedTodo)
+      }
+    }
+
+    const db = getDb(c.env)
+    const [updatedTodo] = await db
+      .update(todosTable)
+      .set(updateData)
+      .where(eq(todosTable.id, id))
+      .returning()
+
+    if (!updatedTodo) {
+      return c.json({ error: 'Todo not found' }, 404)
+    }
+
+    return c.json(updatedTodo)
+  } catch (error) {
+    console.error('Error updating todo:', error)
+    return c.json({ error: 'Failed to update todo' }, 500)
+  }
+}
+
+export async function deleteTodo(c: Context<{ Bindings: Env }>) {
+  try {
+    // biome-ignore lint/suspicious/noExplicitAny: Hono zValidator typing issue
+    const { id } = (c.req as any).valid('param') as ParamType
+
+    if (isTestEnvironment(c.env)) {
+      const mockDb = await getMockDb()
+      if (mockDb) {
+        const deleted = await mockDb.deleteTodo(id)
+        if (!deleted) {
+          return c.json({ error: 'Todo not found' }, 404)
+        }
+        return c.json({ message: 'Todo deleted successfully' })
+      }
+    }
+
+    const db = getDb(c.env)
+    const [deletedTodo] = await db.delete(todosTable).where(eq(todosTable.id, id)).returning()
+
+    if (!deletedTodo) {
+      return c.json({ error: 'Todo not found' }, 404)
+    }
+
+    return c.json({ message: 'Todo deleted successfully', todo: deletedTodo })
+  } catch (error) {
+    console.error('Error deleting todo:', error)
+    return c.json({ error: 'Failed to delete todo' }, 500)
+  }
+}

--- a/apps/api/src/todos/schema.ts
+++ b/apps/api/src/todos/schema.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod'
+
+export const ParamSchema = z.object({
+  id: z
+    .string()
+    .regex(/^\d+$/, 'Invalid ID format')
+    .transform((val) => Number.parseInt(val, 10))
+    .refine((val) => val > 0, 'ID must be positive'),
+})
+
+export const CreateTodoSchema = z.object({
+  title: z
+    .string()
+    .trim()
+    .min(1, 'Title cannot be empty')
+    .max(255, 'Title must be 255 characters or less'),
+  completed: z.boolean().default(false),
+})
+
+export const UpdateTodoSchema = z
+  .object({
+    title: z
+      .string()
+      .trim()
+      .min(1, 'Title cannot be empty')
+      .max(255, 'Title must be 255 characters or less')
+      .optional(),
+    completed: z.boolean().optional(),
+  })
+  .refine(
+    (data) => data.title !== undefined || data.completed !== undefined,
+    'At least one field (title or completed) is required',
+  )
+
+export type ParamType = z.infer<typeof ParamSchema>
+export type CreateTodoType = z.infer<typeof CreateTodoSchema>
+export type UpdateTodoType = z.infer<typeof UpdateTodoSchema>

--- a/apps/api/src/todos/validation.ts
+++ b/apps/api/src/todos/validation.ts
@@ -1,0 +1,88 @@
+// Custom error handlers for backward compatibility with tests
+// Using explicit function declarations to avoid complex type constraints
+// biome-ignore lint/suspicious/noExplicitAny: zValidator Hook type is complex
+export function handleParamValidationError(result: any, c: any) {
+  if (!result.success) {
+    return c.json({ error: 'Invalid ID' }, 400)
+  }
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: zValidator Hook type is complex
+export function handleCreateTodoError(result: any, c: any) {
+  if (!result.success) {
+    const issues = result.error?.issues || []
+    const firstIssue = issues[0]
+
+    if (!firstIssue) {
+      return c.json({ error: 'Invalid JSON' }, 400)
+    }
+
+    // Handle missing required field (title)
+    if (
+      firstIssue.code === 'invalid_type' &&
+      firstIssue.expected === 'string' &&
+      firstIssue.received === 'undefined' &&
+      firstIssue.path?.[0] === 'title'
+    ) {
+      return c.json({ error: 'Title is required and must be a string' }, 400)
+    }
+
+    // Handle wrong type for title
+    if (
+      firstIssue.code === 'invalid_type' &&
+      firstIssue.expected === 'string' &&
+      firstIssue.path?.[0] === 'title'
+    ) {
+      return c.json({ error: 'Title is required and must be a string' }, 400)
+    }
+
+    // Handle title validation errors
+    if (firstIssue?.path?.[0] === 'title') {
+      if (firstIssue.code === 'too_small') {
+        return c.json({ error: 'Title cannot be empty' }, 400)
+      }
+      if (firstIssue.code === 'too_big') {
+        return c.json({ error: 'Title must be 255 characters or less' }, 400)
+      }
+    }
+
+    // Handle completed field errors
+    if (firstIssue?.path?.[0] === 'completed' && firstIssue.code === 'invalid_type') {
+      return c.json({ error: 'Completed must be a boolean' }, 400)
+    }
+
+    return c.json({ error: 'Invalid JSON' }, 400)
+  }
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: zValidator Hook type is complex
+export function handleUpdateTodoError(result: any, c: any) {
+  if (!result.success) {
+    const issues = result.error?.issues || []
+    const firstIssue = issues[0]
+
+    if (!firstIssue) {
+      return c.json({ error: 'Validation failed' }, 400)
+    }
+
+    if (firstIssue?.message === 'At least one field (title or completed) is required') {
+      return c.json({ error: 'At least one field (title or completed) is required' }, 400)
+    }
+    if (firstIssue?.path?.[0] === 'title') {
+      if (firstIssue.code === 'too_small') {
+        return c.json({ error: 'Title cannot be empty' }, 400)
+      }
+      if (firstIssue.code === 'too_big') {
+        return c.json({ error: 'Title must be 255 characters or less' }, 400)
+      }
+      if (firstIssue.code === 'invalid_type') {
+        return c.json({ error: 'Title must be a string' }, 400)
+      }
+      return c.json({ error: 'Title must be a string' }, 400)
+    }
+    if (firstIssue?.path?.[0] === 'completed') {
+      return c.json({ error: 'Completed must be a boolean' }, 400)
+    }
+    return c.json({ error: 'Validation failed' }, 400)
+  }
+}

--- a/apps/api/tests/mock-database.ts
+++ b/apps/api/tests/mock-database.ts
@@ -1,0 +1,18 @@
+import type { Env } from '../src/app'
+
+// テスト環境でのモックDB使用のため
+// biome-ignore lint/suspicious/noExplicitAny: Test mock can be any implementation
+export async function getMockDb(): Promise<any> {
+  // 動的インポートでテストヘルパーを取得（テスト環境でのみ利用可能）
+  try {
+    // biome-ignore lint/suspicious/noExplicitAny: Test helper dynamic import
+    const testHelpers = (await import('./utils/test-helpers')) as any
+    return testHelpers.mockDb
+  } catch {
+    return null
+  }
+}
+
+export function isTestEnvironment(env: Env): boolean {
+  return env.DATABASE_URL?.startsWith('mock://') ?? false
+}


### PR DESCRIPTION
## 概要

todosに関連するファイルを機能別に分割し、より保守しやすい構造に再構成しました。

## 変更内容

### ファイル構造の変更
- **Before**: 単一の299行のファイル (`routes/todos.ts`)
- **After**: 機能別に分割された4つのファイル

### 新しいディレクトリ構造
```
src/todos/
├── schema.ts      # Zodバリデーションスキーマ
├── validation.ts  # エラーハンドリング関数
└── handlers.ts    # HTTPリクエストハンドラー

tests/
└── mock-database.ts  # テスト専用モックDB関数
```

### 主要な改善点
- ✅ **責務分離**: 各ファイルが明確な役割を担当
- ✅ **可読性向上**: メインファイルが299行→36行に簡潔化
- ✅ **保守性向上**: 機能変更時の影響範囲が明確
- ✅ **テストコード分離**: テスト専用コードをtestsディレクトリに配置
- ✅ **スケーラブル**: 他の機能も同様のパターンで整理可能

## 影響範囲

- [x] API アプリ
- [ ] Web アプリ
- [ ] Native アプリ
- [ ] 共有UIコンポーネント
- [ ] TypeScript設定

## 変更の種類

- [ ] 新機能
- [ ] バグ修正
- [x] リファクタリング
- [ ] ドキュメント更新
- [ ] テスト追加/修正
- [ ] その他

## 技術的チェックリスト

- [x] `pnpm fix` 実行済み（自動修正）
- [x] `pnpm check-types` 実行済み（型チェック）
- [x] `pnpm check` 実行済み（包括的チェック）
- [x] 全テスト通過 (72/72)
- [x] 不要なconsole.log削除
- [x] 機能動作確認済み

## 検証方法

```bash
# テスト実行
pnpm --filter @repo/api test

# 型チェック
pnpm check-types

# コード品質チェック
pnpm check
```

## 追加情報

この変更により、将来的に他のエンティティ（users、orders等）を追加する際も同じパターンで整理でき、一貫性のあるコードベースを維持できます。

🤖 Generated with [Claude Code](https://claude.ai/code)